### PR TITLE
Fixed & Update: ItemForm 컴포넌트를 add page 및 details page 에 공용으로 적용

### DIFF
--- a/components/recycle/ItemForm.tsx
+++ b/components/recycle/ItemForm.tsx
@@ -59,7 +59,7 @@ const defaultValues = {
   image: [],
   price: 0,
   color: '',
-  categori: '',
+  categori: '카테고리를 선택해주세요',
   purchaseDay: '',
   categoriItem: {
     shoulder: 0,
@@ -109,20 +109,12 @@ const ItemForm = ({ title, subTitle, type, itemId, Submit, resultNumber, setStat
     const { id, createdAt, updatedAt, ClothId, ...measure } = categoriObject!;
     const { categoriItem, ...rest } = defaultValues;
     const measureItem = { categoriItem: { ...categoriItem, ...measure } };
-    console.log(measureItem);
     beforeValues = { ...singleData, ...measureItem };
-    console.log(beforeValues);
     if (!isDataChange.current) {
       isDataChange.current = true;
       reset(beforeValues);
     }
   }
-
-  useEffect(() => {
-    dispatch({
-      type: t.RESET_UPLOAD_PAGE,
-    });
-  }, []);
 
   // 어차피 singleItem 이 있다면 defaultValue -> beforeValues 로 변경된다.
   useEffect(() => {
@@ -163,6 +155,7 @@ const ItemForm = ({ title, subTitle, type, itemId, Submit, resultNumber, setStat
   const onSubmit = (data: AddInitialValue) => {
     data.image = imagePath;
     const Type = Submit();
+    console.log(data);
     return dispatch({
       type: Type,
       data: { items: data, clothId: itemId },
@@ -222,9 +215,9 @@ const ItemForm = ({ title, subTitle, type, itemId, Submit, resultNumber, setStat
                         let isCategori = v.visionSearch.map(v => v.name).some(item => categoriToVisionAI[cate]?.includes(item));
                         let confidence = categoriToVisionAI[cate]?.includes(v.visionSearch[0].name);
                         return (
-                          <PreviewContainer key={v.filename} border={isClothes}>
+                          <PreviewContainer key={v.src} border={isClothes}>
                             {/* <img src={`${backUrl}/${v.filename}`} alt={v.filename} style={{ width: '250px' }} /> */}
-                            <PreviewImage src={`${backUrl}/${v.filename}`} alt={v.filename} width={250} height={250} />
+                            <PreviewImage src={`${backUrl}/${v.src}`} alt={v.src} width={250} height={250} />
                             <PreviewTextContainer>
                               <PreviewText>
                                 {isClothes ? (

--- a/components/recycle/add/Measure.tsx
+++ b/components/recycle/add/Measure.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { FieldValues, useFormContext } from 'react-hook-form';
 
 import { TControl, TControlArray } from '../element/type';
-import { AddInitialValue } from '../../../pages/closet/add';
+import { AddInitialValue } from '../ItemForm';
 
 import InputBackground from './InputBackgroud';
 import ANumberInput from '../element/ANumberInput';

--- a/components/recycle/element/AInputElement.tsx
+++ b/components/recycle/element/AInputElement.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { CirclePicker } from 'react-color';
 import { FieldValues, useController } from 'react-hook-form';
 import { InputNumber, Select, Input, DatePicker } from 'antd';
@@ -9,8 +10,12 @@ import { TControl } from './type';
 import { media } from '../../../styles/media';
 import { colors } from '../../add/ElementData';
 
+dayjs.extend(customParseFormat);
+
 const { TextArea } = Input;
-const dateFormat = 'YYYY-MM-DD';
+const dateFormat = 'YYYY-MM';
+// 초기 날짜. 현재 날짜
+const currentDate = dayjs().format('YYYY-MM');
 
 export interface ISelectItem {
   label: ReactNode;
@@ -37,7 +42,9 @@ function AInputElement<T extends FieldValues>(props: TPorps<T>) {
       {name == 'productName' ? <Input value={value} id={name} onChange={onChange} {...props} style={{ height: '30px', width: '100%' }} autoComplete='off' allowClear /> : null}
       {name == 'color' ? <CirclePicker color={value} colors={colors} onChange={(color, event) => onChange(color.hex)} {...props} circleSize={25} width='100%' /> : null}
       {name == 'price' ? <InputNumber value={value} id={name} min={1} onChange={onChange} style={{ height: '30px', width: '100%' }} placeholder={placeholder} /> : null}
-      {name == 'purchaseDay' ? <DatePicker value={dayjs(value)} onChange={(date, dateString) => onChange(dateString)} picker='month' style={{ width: '100%', height: '30px' }} /> : null}
+      {name == 'purchaseDay' ? (
+        <DatePicker defaultValue={dayjs(value || currentDate, dateFormat)} onChange={(date, dateString) => onChange(dateString)} picker='month' style={{ width: '100%', height: '30px' }} />
+      ) : null}
       {name == 'description' ? <TextArea value={value} id={name} onChange={onChange} placeholder={placeholder} rows={5} style={{ width: '100%' }} /> : null}
       {name == 'categori' ? <Select defaultValue={defaultValue} value={value} id={name} options={options} onChange={onChange} style={{ height: '30px', width: '100%' }} /> : null}
       <ErrorMessage>{error && errorMessage}</ErrorMessage>

--- a/etc/hydrate-error.tsx
+++ b/etc/hydrate-error.tsx
@@ -1,0 +1,21 @@
+import React, { useState, useEffect } from 'react';
+
+const hydrateError = () => {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  if (!hydrated) {
+    return null;
+  }
+
+  return (
+    <>
+      <div>hydrate 에러 대처</div>
+    </>
+  );
+};
+
+export default hydrateError;

--- a/pages/closet/add.tsx
+++ b/pages/closet/add.tsx
@@ -1,383 +1,67 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import styled, { css } from 'styled-components';
-import { useDispatch } from 'react-redux';
 import * as t from '../../reducers/type';
-import Image from 'next/image';
 
-import { FieldValues, useForm, FormProvider, FieldPath } from 'react-hook-form';
-import { clothData, categori, descriptionData } from '../../components/add/ElementData';
-import { visionAI, categoriToVisionAI } from '../../components/add/VisionAIData';
-import { topMeasureName, bottomMeasureName, shoesMeasureName, mufflerMeasureName } from '../../components/add/ElementData';
-import { topMeasureSub, bottomMeasureSub, shoesMeasureSub, mufflerMeasureSub } from '../../components/add/ElementData';
+import axios from 'axios';
+import { END } from 'redux-saga';
 
-import { backUrl } from '../../config/config';
+import { GetServerSidePropsContext } from 'next';
+import type { SagaStore } from '../../store/configureStore';
+
+import wrapper from '../../store/configureStore';
+
 import PageLayout from '../../components/recycle/PageLayout';
-import PageMainLayout from '../../components/recycle/main/PageMainLayout';
 
-import AInputElement from '../../components/recycle/element/AInputElement';
-import Measure from '../../components/recycle/add/Measure';
-import InputBackground from '../../components/recycle/add/InputBackgroud';
-import SortingResultComponent from '../../components/recycle/submitSuccess/SortingResultComponent';
-import AButton from '../../components/recycle/element/button/AButton';
-import InputPartial from '../../components/recycle/add/InputPartial';
-import DropImageInput from '../../components/recycle/element/DropImageInput';
 import { useSelector } from 'react-redux';
 import { rootReducerType } from '../../reducers/types';
 
-import { WarningTwoTone, CheckCircleTwoTone, CloseCircleTwoTone } from '@ant-design/icons';
+import ItemForm from '../../components/recycle/ItemForm';
 
-import type { ImagePathObject } from '../../reducers/types/post';
-
-export interface Measures {
-  shoulder?: number;
-  arm?: number;
-  totalLength?: number;
-  chest?: number;
-  rise?: number;
-  hem?: number;
-  waist?: number;
-  thigh?: number;
-  size?: number;
-}
-
-export interface AddInitialValue extends FieldValues {
-  productName: string;
-  description: string;
-  image: ImagePathObject[];
-  price: number;
-  color: string;
-  categori: string;
-  purchaseDay: string;
-  categoriItem: Measures;
-}
-
-const defaultValues = {
-  productName: '',
-  description: '',
-  image: [],
-  price: 0,
-  color: '',
-  categori: '',
-  purchaseDay: '',
-  categoriItem: {
-    shoulder: 0,
-    arm: 0,
-    totalLength: 0,
-    chest: 0,
-    rise: 0,
-    hem: 0,
-    waist: 0,
-    thigh: 0,
-    size: 0,
-  },
-};
+import { addPageLayoutProps } from '../../components/add/ElementData';
 
 const add = () => {
-  const dispatch = useDispatch();
-  const [isClothes, setIsClothes] = useState(false);
   const [hydrated, setHydrated] = useState(false);
-  const { imagePath, uploadItemsDone, lastAddDataIndex } = useSelector((state: rootReducerType) => state.post);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [dragActive, setDragActive] = useState<boolean>(false);
-  const methods = useForm<AddInitialValue>({
-    mode: 'onSubmit',
-    defaultValues: defaultValues,
-  });
+  const { lastAddDataIndex } = useSelector((state: rootReducerType) => state.post);
 
-  const { handleSubmit, control, watch, reset } = methods;
-
-  // 짜증난다... 도대체 왜.
-  useEffect(() => {
-    setHydrated(true);
+  const transferTypes = useCallback(() => {
+    return t.UPLOAD_ITEMS_REQUEST;
   }, []);
-
-  useEffect(() => {
-    dispatch({
-      type: t.RESET_UPLOAD_PAGE,
-    });
-  }, []);
-
-  useEffect(() => {
-    reset({ defaultValues });
-  }, [uploadItemsDone]);
-
-  useEffect(() => {
-    if (imagePath.length === 0) {
-      return;
-    }
-    let visionSearch = imagePath.map(v => v.visionSearch?.some(i => visionAI.includes(i.name)));
-    if (visionSearch.every(bool => bool === true)) {
-      setIsClothes(true);
-    } else {
-      setIsClothes(false);
-    }
-  }, [imagePath]);
-
-  const onRemoveImage = useCallback(
-    (index: number) => () => {
-      dispatch({
-        type: t.REMOVE_IMAGE,
-        data: index,
-      });
-    },
-    []
-  );
-
-  const onSubmit = (data: AddInitialValue) => {
-    data.image = imagePath;
-    return dispatch({
-      type: t.UPLOAD_ITEMS_REQUEST,
-      data: data,
-    });
-  };
-
-  if (!hydrated) {
-    return null;
-  }
 
   return (
     <PageLayout>
-      {!uploadItemsDone && (
-        <PageMainLayout title='ADD CLOTHES' subTitle='현 가정 옷장에 보관되어있는 의류의 이름과 색상, 종류 등 각각의 특성들을 기입하여 저장할 수 있습니다. '>
-          <TestContainer>
-            <AddSection>
-              <FormProvider {...methods}>
-                <AddForm onSubmit={handleSubmit(onSubmit)}>
-                  <InputPartial title='SPECIFICATION' subtitle='의류 명칭, 가격 등 특성 정보를 저장해주세요. 필수 기입입니다.'>
-                    {clothData.map(v => {
-                      return (
-                        <InputBackground key={v.name} title={v.name} subTitle={v.subTitle}>
-                          <AInputElement control={control} name={v.name} errorMessage={v.errorMessage} placeholder={v.placeholder} rules={{ required: true }} />
-                        </InputBackground>
-                      );
-                    })}
-                  </InputPartial>
-                  <InputPartial title='SORT CLOTHES' subtitle='카테고리를 선택해주시고, 각 카테고리에 맞는 측정치수를 cm 단위로 기입해주세요. 카테고리를 기입하셔야 이미지체크가 가능합니다'>
-                    {categori.map(v => {
-                      return (
-                        <InputBackground key={v.name} title={v.name} subTitle={v.subTitle}>
-                          <AInputElement control={control} name={v.name} errorMessage={v.errorMessage} options={v.options} defaultValue={v.defaultValue} rules={{ required: true }} />
-                        </InputBackground>
-                      );
-                    })}
-                    {['Outer', 'Shirt', 'Top'].includes(watch('categori')) ? <Measure control={control} nameArray={topMeasureName} subTitleArray={topMeasureSub} placeholder='cm' /> : null}
-                    {['Pant'].includes(watch('categori')) ? <Measure control={control} nameArray={bottomMeasureName} subTitleArray={bottomMeasureSub} placeholder='cm' /> : null}
-                    {['Shoe'].includes(watch('categori')) ? <Measure control={control} nameArray={shoesMeasureName} subTitleArray={shoesMeasureSub} placeholder='mm' /> : null}
-                    {['Muffler'].includes(watch('categori')) ? <Measure control={control} nameArray={mufflerMeasureName} subTitleArray={mufflerMeasureSub} placeholder='cm' /> : null}
-                  </InputPartial>
-                  <InputPartial title='ABOUT ITEM' subtitle='의류에 대한 설명을 기입하실 수 있습니다. 구입처나 소재, 보관방법 등 구체적인 사안을 저장하실 수 있습니다.'>
-                    {descriptionData.map(v => {
-                      return (
-                        <InputBackground key={v.name} title={v.name} subTitle={v.subTitle} textArea={true}>
-                          <AInputElement control={control} name={v.name} placeholder={v.placeholder} />
-                        </InputBackground>
-                      );
-                    })}
-                  </InputPartial>
-                  <InputPartial
-                    title='IMAGE UPLOAD'
-                    subtitle='이미지를 하나씩 업로드 할 수 있습니다. 필수 기입사항입니다. 이미지를 업로드 할 시 vision AI 를 통해 이미지의 적합성을 판단하게 됩니다. 허나 이는 참고용으로서 부정확할 수 있으니 주의바랍니다.'
-                  >
-                    <DropImageInput />
-                  </InputPartial>
-                  <PreviewSection>
-                    {imagePath.length > 0 &&
-                      imagePath.map((v, i) => {
-                        let cate = watch('categori');
-                        let isClothes = v.visionSearch?.some(v => visionAI.includes(v.name));
-                        let isCategori = v.visionSearch?.map(v => v.name).some(item => categoriToVisionAI[cate]?.includes(item));
-                        let confidence = categoriToVisionAI[cate]?.includes(v.visionSearch[0].name);
-                        return (
-                          <PreviewContainer key={v.filename} border={isClothes}>
-                            {/* <img src={`${backUrl}/${v.filename}`} alt={v.filename} style={{ width: '250px' }} /> */}
-                            <PreviewImage src={`${backUrl}/${v.filename}`} alt={v.filename} width={250} height={250} />
-                            <PreviewTextContainer>
-                              <PreviewText>
-                                {isClothes ? (
-                                  <TextBox>
-                                    <span>의류 사진여부 판단</span>
-                                    <Text>
-                                      <CheckCircleTwoTone twoToneColor='#52c41a' />
-                                      적절한 사진입니다.
-                                    </Text>
-                                  </TextBox>
-                                ) : (
-                                  <TextBox>
-                                    <span>의류 사진여부 판단</span>
-                                    <Text>
-                                      <CloseCircleTwoTone twoToneColor='#E7373C' />
-                                      의류 사진을 넣어주세요
-                                    </Text>
-                                  </TextBox>
-                                )}
-                                {isCategori ? (
-                                  <TextBox>
-                                    <span>카테고리 적합성</span>
-                                    <Text>
-                                      <CheckCircleTwoTone twoToneColor='#52c41a' />
-                                      카테고리에 적합한 의류입니다
-                                    </Text>
-                                  </TextBox>
-                                ) : (
-                                  <TextBox>
-                                    <span>카테고리 적합성</span>
-                                    <Text>
-                                      <WarningTwoTone twoToneColor='#F4A100' />
-                                      저장하실 순 있지만 적합의류는 아닙니다.
-                                    </Text>
-                                  </TextBox>
-                                )}
-                                {confidence ? (
-                                  <TextBox>
-                                    <span>사진 내 카테고리 이미지 차지 비율</span>
-                                    <Text>
-                                      <CheckCircleTwoTone twoToneColor='#52c41a' />
-                                      의류 비중이 적합합니다.
-                                    </Text>
-                                  </TextBox>
-                                ) : (
-                                  <TextBox>
-                                    <span>사진 내 카테고리 이미지 차지 비율</span>
-                                    <Text>
-                                      <WarningTwoTone twoToneColor='#F4A100' />좀 더 적합의류의 비중이 높은 사진을 올려주세요
-                                    </Text>
-                                  </TextBox>
-                                )}
-                              </PreviewText>
-
-                              <ButtonBox>
-                                <AButton color='' disabled={false} dest='제거' onClick={onRemoveImage(i)} />
-                              </ButtonBox>
-                            </PreviewTextContainer>
-                          </PreviewContainer>
-                        );
-                      })}
-                  </PreviewSection>
-                  <Float>
-                    <SubmitButton>
-                      <AButton type='submit' color='black' dest='저장하기' disabled={!isClothes} />
-                    </SubmitButton>
-                  </Float>
-                </AddForm>
-              </FormProvider>
-            </AddSection>
-          </TestContainer>
-        </PageMainLayout>
-      )}
-      {uploadItemsDone && <SortingResultComponent sort='add' id={lastAddDataIndex} />}
+      <ItemForm title={addPageLayoutProps.title} subTitle={addPageLayoutProps.subTitle} type='add' resultNumber={lastAddDataIndex} Submit={transferTypes} />
     </PageLayout>
   );
 };
 
+export const getServerSideProps = wrapper.getServerSideProps(store => async (context: GetServerSidePropsContext) => {
+  const cookie = context.req ? context.req.headers.cookie : '';
+  axios.defaults.headers.Cookie = '';
+  if (context.req && cookie) {
+    axios.defaults.headers.Cookie = cookie;
+  }
+  store.dispatch({
+    // store에서 dispatch 하는 api
+    type: t.LOAD_TO_MY_INFO_REQUEST,
+  });
+
+  store.dispatch({
+    type: t.RESET_UPLOAD_PAGE,
+  });
+
+  store.dispatch(END);
+  await (store as SagaStore).sagaTask?.toPromise();
+  // if (!store.getState().user.me) {
+  //   // getState() 는 store의 트리를 가져와준다.
+  //   return {
+  //     redirect: {
+  //       destination: '/userlogin',
+  //       permanent: false,
+  //     },
+  //   };
+  // }
+  return {
+    props: {},
+  };
+});
+
 export default React.memo(add);
-
-const TestContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  height: auto;
-  background-color: ${({ theme }) => theme.colors.white};
-`;
-
-const AddSection = styled.div`
-  display: flex;
-  width: 100%;
-  height: auto;
-`;
-
-const Row = styled.div`
-  width: 100%;
-  height: 100%;
-`;
-
-const AddForm = styled.form`
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 10px;
-  width: 100%;
-  height: auto;
-  padding: 10px 0;
-`;
-
-const PreviewSection = styled.section`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 5px;
-  flex-wrap: wrap;
-`;
-
-const PreviewContainer = styled.div<{ border: boolean }>`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  max-width: 530px;
-  height: auto;
-  padding: 10px;
-  border: 1px solid ${({ theme, border }) => (border ? theme.colors.success : theme.colors.red)};
-  border-radius: 5px;
-  gap: 30px;
-  transition: box-shadow 0.25s ease-out;
-
-  &:hover {
-    box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
-  }
-`;
-
-const PreviewImage = styled(Image)`
-  width: 250px;
-  height: 250px;
-  object-fit: cover;
-`;
-
-const PreviewTextContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: c;
-  height: 100%;
-`;
-
-const PreviewText = styled.div`
-  margin-top: 10px;
-`;
-
-const TextBox = styled.div`
-  display: inline-block;
-  margin-bottom: 5px;
-
-  > span {
-    display: inline-block;
-    font-size: 11px;
-    font-weight: ${({ theme }) => theme.fontWeight.Light};
-    font-family: ${({ theme }) => theme.font.Efont};
-    color: ${({ theme }) => theme.colors.deepGrey};
-    margin-bottom: 5px;
-  }
-`;
-
-const Text = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 6px;
-  font-size: 14px;
-  font-weight: ${({ theme }) => theme.fontWeight.Medium};
-  font-family: ${({ theme }) => theme.font.Efont};
-`;
-
-const ButtonBox = styled.div`
-  margin-top: 20px;
-`;
-
-const Float = styled.div`
-  display: flex;
-  width: 100%;
-  justify-content: flex-end;
-  align-items: center;
-`;
-
-const SubmitButton = styled.div`
-  width: 200px;
-`;

--- a/reducers/post.tsx
+++ b/reducers/post.tsx
@@ -65,6 +65,7 @@ export default (state = initialState, action: AnyAction) => {
         draft.loadItemDone = true;
         draft.loadItemError = false;
         draft.singleItem = action.data;
+        draft.imagePath = action.data.Images;
         break;
       }
       case t.LOAD_ITEM_FAILURE: {

--- a/reducers/types/post.ts
+++ b/reducers/types/post.ts
@@ -4,7 +4,7 @@ export interface VisionSearch {
 }
 
 export interface ImagePathObject {
-  filename: string;
+  src: string;
   visionSearch: VisionSearch[];
 }
 


### PR DESCRIPTION
### Fixed: ItemForm 

- 현재 두개의 페이지에서 재사용할 수 있도록, props 를 조정
- 특히, react-hook-form 내 submit 함수 전체를 props 로 전달하는 경우 인자로 전달해주는 data 를 props 로 전달할 수 없기 때문에, (이 데이터는 hook-form 내 참조 가능한 데이터) action 의 type 만 페이지에 적합하게 전달하였다.
- add 페이지의 경우 upload, details page 의 경우 patch 타입을 전달하였다.
- 공용으로 내부에서 사용되는 result component, button component 와의 연계를 고려한 type props 를 전달함으로서 상황에 맞는 컴포넌트 함수와 렌더링이 이루어질 수 있었다.
- 기존 imagePath 에서 백엔드로 전송 시 src 만 전송하게 되어, 데이터 수정 시 기존 데이터 렌더링 과정에서 사진과 함께 사진적합도에 대한 알림문이 렌더될 수 없어서, 테이블 column 을 추가하고, visionSearch 데이터를 같이 송부하도록 수정했음.
- 현 한계점은 객체의 배열로서는 테이블에 저장할 수 없어서, 이후 visionSearch 부분의 데이터 형식 수정이 필요함

### Update: 각각의 페이지에 ItemForm 적용

- 기존 add 페이지 내 제출부분을 ItemForm 컴포넌트로 대체
- 대체하는 과정에서 발생하고 있었던 hydrate 에러 자연스럽게 해결됨
(there was a difference between the React tree that was pre-rendered (SSR/SSG) and the React tree that rendered during the first render in the Browser)
