### PR TITLE
Fixed & Add :  디테일 페이지 렌더링 절차 수정, 삭제 기능 추가하기

### DIFF
--- a/components/recycle/ItemForm.tsx
+++ b/components/recycle/ItemForm.tsx
@@ -146,17 +146,16 @@ const ItemForm = ({ title, subTitle, type, itemId, Submit, resultNumber, setStat
   );
 
   const backDetailsPage = useCallback(() => {
-    Router.push(`/closet/details/${itemId}`);
     if (setState) {
       setState(prev => !prev);
     }
-  }, [itemId]);
+  }, []);
 
   const onSubmit = (data: AddInitialValue) => {
     data.image = imagePath;
     const Type = Submit();
     console.log(data);
-    return dispatch({
+    dispatch({
       type: Type,
       data: { items: data, clothId: itemId },
     });
@@ -293,7 +292,7 @@ const ItemForm = ({ title, subTitle, type, itemId, Submit, resultNumber, setStat
                         <AButton type='submit' color='black' dest='수정하기' disabled={!isClothes} />
                       </SubmitButton>
                       <SubmitButton>
-                        <AButton color='' dest='이전으로' onClick={backDetailsPage} disabled={isClothes} />
+                        <AButton color='' dest='이전으로' onClick={backDetailsPage} disabled={false} />
                       </SubmitButton>
                     </Float>
                   )}
@@ -303,7 +302,7 @@ const ItemForm = ({ title, subTitle, type, itemId, Submit, resultNumber, setStat
           </TestContainer>
         </PageMainLayout>
       )}
-      {uploadItemsDone && <SortingResultComponent sort={type} id={resultNumber} />}
+      {uploadItemsDone && <SortingResultComponent sort={type} id={resultNumber} setConvertState={setState} />}
     </>
   );
 };

--- a/components/recycle/ItemForm.tsx
+++ b/components/recycle/ItemForm.tsx
@@ -88,7 +88,7 @@ const ItemForm = ({ title, subTitle, type, itemId, Submit, resultNumber, setStat
   const dispatch = useDispatch();
   const [isClothes, setIsClothes] = useState(false);
   const isDataChange = useRef(false);
-  const { imagePath, uploadItemsDone, lastAddDataIndex, singleItem } = useSelector((state: rootReducerType) => state.post);
+  const { imagePath, uploadItemsDone, uploadItemsError, lastAddDataIndex, singleItem } = useSelector((state: rootReducerType) => state.post);
   const methods = useForm<AddInitialValue>({
     mode: 'onSubmit',
     defaultValues: defaultValues,
@@ -110,9 +110,16 @@ const ItemForm = ({ title, subTitle, type, itemId, Submit, resultNumber, setStat
     const { categoriItem, ...rest } = defaultValues;
     const measureItem = { categoriItem: { ...categoriItem, ...measure } };
     beforeValues = { ...singleData, ...measureItem };
+    // 무한 렌더링을 막기 위함이다.
     if (!isDataChange.current) {
       isDataChange.current = true;
       reset(beforeValues);
+    }
+  } else {
+    // 역시나 무한 랜더링을 막기 위함이다.
+    if (isDataChange.current) {
+      isDataChange.current = false;
+      reset(defaultValues);
     }
   }
 
@@ -163,7 +170,7 @@ const ItemForm = ({ title, subTitle, type, itemId, Submit, resultNumber, setStat
 
   return (
     <>
-      {!uploadItemsDone && (
+      {!uploadItemsDone ? (
         <PageMainLayout title={title} subTitle={subTitle}>
           <TestContainer>
             <AddSection>
@@ -301,8 +308,9 @@ const ItemForm = ({ title, subTitle, type, itemId, Submit, resultNumber, setStat
             </AddSection>
           </TestContainer>
         </PageMainLayout>
-      )}
-      {uploadItemsDone && <SortingResultComponent sort={type} id={resultNumber} setConvertState={setState} />}
+      ) : null}
+      {uploadItemsDone ? <SortingResultComponent sort={type} id={resultNumber} setConvertState={setState} /> : null}
+      {uploadItemsError ? <SortingResultComponent sort={`${type}Failure`} id={resultNumber} setConvertState={setState} /> : null}
     </>
   );
 };

--- a/components/recycle/submitSuccess/SortingResultComponent.tsx
+++ b/components/recycle/submitSuccess/SortingResultComponent.tsx
@@ -9,9 +9,10 @@ import { useDispatch } from 'react-redux';
 type Props = {
   sort: ResultDataKey;
   id: number | '';
+  setConvertState?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const SortingResultComponent = ({ sort, id }: Props) => {
+const SortingResultComponent = ({ sort, id, setConvertState }: Props) => {
   const dispatch = useDispatch();
   const data = Data[sort];
   const { title, subTitle, buttonNamePrimary, buttonName, status, primaryPage, otherPage } = data;
@@ -19,6 +20,9 @@ const SortingResultComponent = ({ sort, id }: Props) => {
   const movePage = useCallback(
     (page: string, id: '' | number) => () => {
       Router.push(`/closet/${page}/${id}`);
+      if (setConvertState) {
+        setConvertState(prev => !prev);
+      }
       if (page === 'add') {
         dispatch({
           type: t.RESET_UPLOAD_PAGE,

--- a/components/recycle/submitSuccess/SortingResultComponent.tsx
+++ b/components/recycle/submitSuccess/SortingResultComponent.tsx
@@ -19,14 +19,19 @@ const SortingResultComponent = ({ sort, id, setConvertState }: Props) => {
 
   const movePage = useCallback(
     (page: string, id: '' | number) => () => {
-      Router.push(`/closet/${page}/${id}`);
-      if (setConvertState) {
-        setConvertState(prev => !prev);
-      }
       if (page === 'add') {
         dispatch({
           type: t.RESET_UPLOAD_PAGE,
         });
+      }
+      if (page === 'details') {
+        Router.push(`/closet/${page}/${id}`);
+      } else {
+        Router.push(`/closet/${page}`);
+      }
+
+      if (setConvertState) {
+        setConvertState(prev => !prev);
       }
     },
     []

--- a/components/recycle/submitSuccess/data.ts
+++ b/components/recycle/submitSuccess/data.ts
@@ -37,6 +37,24 @@ export const Data = {
     otherPage: 'overview',
     status: 'error',
   },
+  deleteItem: {
+    title: '의류를 삭제하였습니다!',
+    subTitle: '목록 페이지로 이동하고 싶으시다면 목록보기를, 더 저장하시려면 계속 저장하기를 눌러주세요',
+    buttonNamePrimary: '목록보기',
+    buttonName: '저장하기',
+    primaryPage: 'store',
+    otherPage: 'add',
+    status: 'success',
+  },
+  deleteItemFailure: {
+    title: '의류 삭제에 실패하였습니다',
+    subTitle: '알 수 없는 오류가 발생하였습니다. 다시 시도해주세요 ',
+    buttonNamePrimary: '상세 페이지로',
+    buttonName: '메인페이지로',
+    primaryPage: 'details',
+    otherPage: 'overview',
+    status: 'error',
+  },
 } as const;
 
 export type ResultData = typeof Data;

--- a/hooks/useComfirm.tsx
+++ b/hooks/useComfirm.tsx
@@ -1,0 +1,21 @@
+import React, { useCallback } from 'react';
+
+type Props = {
+  description: string;
+  onSubmit: () => void;
+  onCencel: () => void;
+};
+
+const useConfirm = (description: string, onSubmit: () => void, onCencel: () => void) => {
+  const confirm = useCallback(() => {
+    if (window.confirm(description)) {
+      onSubmit();
+    } else {
+      onCencel();
+    }
+  }, [description, onSubmit, onCencel]);
+
+  return confirm;
+};
+
+export default useConfirm;

--- a/pages/closet/add.tsx
+++ b/pages/closet/add.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import * as t from '../../reducers/type';
 
 import axios from 'axios';
@@ -19,7 +19,6 @@ import ItemForm from '../../components/recycle/ItemForm';
 import { addPageLayoutProps } from '../../components/add/ElementData';
 
 const add = () => {
-  const [hydrated, setHydrated] = useState(false);
   const { lastAddDataIndex } = useSelector((state: rootReducerType) => state.post);
 
   const transferTypes = useCallback(() => {

--- a/pages/closet/details/[id].tsx
+++ b/pages/closet/details/[id].tsx
@@ -28,11 +28,13 @@ import ItemForm from '../../../components/recycle/ItemForm';
 
 import { media } from '../../../styles/media';
 import { addPageLayoutProps } from '../../../components/details/ElementData';
+import useConfirm from '../../../hooks/useComfirm';
+import SortingResultComponent from '../../../components/recycle/submitSuccess/SortingResultComponent';
 
 const Details = () => {
   const router = useRouter();
   const dispatch = useDispatch();
-  const { singleItem } = useSelector((state: rootReducerType) => state.post);
+  const { singleItem, deleteItemDone, deleteItemError } = useSelector((state: rootReducerType) => state.post);
   const { id } = router.query;
   const [isModifyMode, setIsModifyMode] = useState(false);
   const [hydrated, setHydrated] = useState(false);
@@ -42,6 +44,27 @@ const Details = () => {
   useEffect(() => {
     setHydrated(true);
   }, []);
+
+  const transferTypes = useCallback(() => {
+    return t.PATCH_ITEM_REQUEST;
+  }, []);
+
+  const startModify = useCallback(() => {
+    setIsModifyMode(true);
+  }, []);
+
+  const deleteItem = () => {
+    dispatch({
+      type: t.DELETE_ITEM_REQUEST,
+      data: { clothId: id },
+    });
+  };
+
+  const cencelDelete = () => {
+    console.log('취소하였습니다.');
+  };
+
+  const deleteConfirm = useConfirm('정말 의류를 삭제하시겠습니까?', deleteItem, cencelDelete);
 
   let measureObject = null;
   let measureValue: [string, number][] = [['name', 1]];
@@ -57,25 +80,15 @@ const Details = () => {
     });
   }
 
-  const transferTypes = useCallback(() => {
-    return t.PATCH_ITEM_REQUEST;
-  }, []);
-
-  const startModify = useCallback(() => {
-    setIsModifyMode(true);
-  }, []);
-
-  if (!singleItem) {
-    return <div>빈페이지</div>;
-  }
-
   if (!hydrated) {
     return null;
   }
 
   return (
     <PageLayout>
-      {!isModifyMode ? (
+      {deleteItemDone ? <SortingResultComponent sort='deleteItem' id={Number(id)} /> : null}
+      {deleteItemError ? <SortingResultComponent sort='deleteItemFailure' id={Number(id)} /> : null}
+      {!deleteItemDone && !deleteItemError && !isModifyMode ? (
         <PageMainLayout istitle={false}>
           <HandleContainer>
             <CustomBread separator='>'>
@@ -89,7 +102,7 @@ const Details = () => {
             </CustomBread>
             <ButtonContainer>
               <AButton color='black' disabled={false} onClick={startModify} dest='수정' />
-              <AButton color='' disabled={false} dest='삭제' />
+              <AButton color='' disabled={false} dest='삭제' onClick={deleteConfirm} />
             </ButtonContainer>
           </HandleContainer>
 
@@ -152,12 +165,13 @@ const Details = () => {
           </SliceContainer>
           <ButtonBottomContainer>
             <AButton color='black' disabled={false} onClick={startModify} dest='수정' />
-            <AButton color='' disabled={false} dest='삭제' />
+            <AButton color='' disabled={false} dest='삭제' onClick={deleteConfirm} />
           </ButtonBottomContainer>
         </PageMainLayout>
-      ) : (
+      ) : null}
+      {!deleteItemDone && !deleteItemError && isModifyMode ? (
         <ItemForm title={title} subTitle={subTitle} type='details' itemId={Number(id)} resultNumber={Number(id)} Submit={transferTypes} setState={setIsModifyMode} />
-      )}
+      ) : null}
     </PageLayout>
   );
 };

--- a/reducers/post.tsx
+++ b/reducers/post.tsx
@@ -15,6 +15,9 @@ export const initialState: PostInitialState = {
   imageUploadLoding: false,
   imageUploadDone: false,
   imageUploadError: false,
+  deleteItemLoding: false,
+  deleteItemDone: false,
+  deleteItemError: false,
   lastAddDataIndex: '',
   user: null,
   imagePath: [],
@@ -34,6 +37,24 @@ export default (state = initialState, action: AnyAction) => {
       }
       case t.RESET_UPLOAD_PAGE: {
         draft.uploadItemsDone = false;
+        break;
+      }
+      case t.DELETE_ITEM_REQUEST: {
+        draft.deleteItemLoding = true;
+        draft.deleteItemDone = false;
+        draft.deleteItemError = false;
+        break;
+      }
+      case t.DELETE_ITEM_SUCCESS: {
+        draft.deleteItemLoding = false;
+        draft.deleteItemDone = true;
+        draft.deleteItemError = false;
+        break;
+      }
+      case t.DELETE_ITEM_FAILURE: {
+        draft.deleteItemLoding = false;
+        draft.deleteItemDone = false;
+        draft.deleteItemError = action.error;
         break;
       }
       case t.PATCH_ITEM_REQUEST: {
@@ -106,7 +127,6 @@ export default (state = initialState, action: AnyAction) => {
         draft.user = action.data;
         draft.lastAddDataIndex = action.data.id;
         draft.imagePath = [];
-        alert('저장되었습니다.');
         break;
       }
       case t.UPLOAD_ITEMS_FAILURE: {

--- a/reducers/type.tsx
+++ b/reducers/type.tsx
@@ -45,3 +45,7 @@ export const LOAD_ITEM_FAILURE = 'LOAD_ITEM_FAILURE' as const;
 export const PATCH_ITEM_REQUEST = 'PATCH_ITEM_REQUEST' as const;
 export const PATCH_ITEM_SUCCESS = 'PATCH_ITEM_SUCCESS' as const;
 export const PATCH_ITEM_FAILURE = 'PATCH_ITEM_FAILURE' as const;
+
+export const DELETE_ITEM_REQUEST = 'DELETE_ITEM_REQUEST' as const;
+export const DELETE_ITEM_SUCCESS = 'DELETE_ITEM_SUCCESS' as const;
+export const DELETE_ITEM_FAILURE = 'DELETE_ITEM_FAILURE' as const;

--- a/reducers/types/post.ts
+++ b/reducers/types/post.ts
@@ -89,6 +89,9 @@ export interface PostInitialState {
   imageUploadLoding: boolean;
   imageUploadDone: boolean;
   imageUploadError: boolean;
+  deleteItemLoding: boolean;
+  deleteItemDone: boolean;
+  deleteItemError: boolean;
   lastAddDataIndex: number | '';
   user: User | null;
   imagePath: ImagePathObject[];

--- a/sagas/post.tsx
+++ b/sagas/post.tsx
@@ -84,12 +84,12 @@ function* loadItem(action: AnyAction) {
   }
 }
 
-type patchItem = {
+type patchProps = {
   items: AddInitialValue;
   clothId: number;
 };
 
-function patchItemAPI(data: patchItem) {
+function patchItemAPI(data: patchProps) {
   return axios.patch(`/post/clothes/${data.clothId}`, data);
 }
 
@@ -111,6 +111,30 @@ function* patchItem(action: AnyAction) {
   }
 }
 
+type deleteProps = Pick<patchProps, 'clothId'>;
+
+function deleteItemAPI(data: deleteProps) {
+  return axios.delete(`/post/clothes/${data.clothId}`);
+}
+
+function* deleteItem(action: AnyAction) {
+  try {
+    console.log('saga delete');
+    console.log(action.data);
+    const result: AxiosResponse<Success> = yield call(deleteItemAPI, action.data);
+    yield put({
+      type: t.DELETE_ITEM_SUCCESS,
+      data: result.data,
+    });
+  } catch (err: any) {
+    console.log(err);
+    yield put({
+      type: t.DELETE_ITEM_FAILURE,
+      error: err.response.data,
+    });
+  }
+}
+
 function* watchImageUpload() {
   yield takeLatest(t.UPLOAD_IMAGES_REQUEST, uploadImage);
 }
@@ -127,6 +151,10 @@ function* watchItemPatch() {
   yield takeLatest(t.PATCH_ITEM_REQUEST, patchItem);
 }
 
+function* watchItemDelete() {
+  yield takeLatest(t.DELETE_ITEM_REQUEST, deleteItem);
+}
+
 export default function* postSaga() {
-  yield all([fork(watchImageUpload), fork(watchItemsUpload), fork(watchItemLoad), fork(watchItemPatch)]);
+  yield all([fork(watchImageUpload), fork(watchItemsUpload), fork(watchItemLoad), fork(watchItemPatch), fork(watchItemDelete)]);
 }


### PR DESCRIPTION
## 삭제 기능 구현

- 서버내에서 api 를 설계했기에 프론트단에서는 크게 설정할 건 없었음
- 다만 삭제 완료 페이지가 렌더링 되어야 했기에, action 을 통해 deleteItemDone 을 true 로 변경시켜주고, 이를 가져와 상세페이지 렌더링에 조건식으로 적용하였음
- 다만, 삭제 완료페이지 -> 더 저장하기 버튼 -> add 페이지 이동 시 기존 singleItem 으로부터 적용된 input value 가 그대로 유지되는 문제가 발생
- itemForm 컴포넌트 내 로직을 수정하여 singleItem 이 없다면 defaultValue 로 다시 form 을 랜더하는 방식을 적용함
- useEffect 를 사용하지 않기위해 useRef 를 활용하였음
- 그 외 에러 페이지도 추가