### PR TITLE
Update: 서버로부터 store 첫 페이지 데이터 가져오기

### DIFF
--- a/components/recycle/ATable.tsx
+++ b/components/recycle/ATable.tsx
@@ -2,7 +2,8 @@ import Image from 'next/image';
 import Router from 'next/router';
 import React, { useCallback } from 'react';
 import styled, { css } from 'styled-components';
-import { StoreHeaderType, StoreItemsType } from '../store/TableData';
+import { Empty } from 'antd';
+import { StoreHeaderType, StoreItemsType, ItemsArray } from '../store/TableData';
 
 import { backUrl } from '../../config/config';
 
@@ -11,7 +12,7 @@ import { BiDetail } from 'react-icons/bi';
 
 type TableProps = {
   headData: StoreHeaderType[];
-  itemsData: StoreItemsType[];
+  itemsData: ItemsArray[] | undefined;
   isDelete?: boolean;
   onSubmit?: (id: number) => () => void;
 };
@@ -39,37 +40,41 @@ const ATable = ({ headData, itemsData = [], isDelete, onSubmit }: TableProps) =>
         </tr>
       </Thead>
       <tbody>
-        {itemsData.map((data, index) => {
-          return (
-            <Tr key={index}>
-              {headerKey.map(headKey => {
-                return (
-                  <Td key={headKey + index}>
-                    {headKey === 'productName' && data.images ? (
-                      <ImageBox>
-                        <CImage src={`${backUrl}/${data.images}`} alt={headKey} width={100} height={100} />
-                        {data[headKey]}
-                      </ImageBox>
-                    ) : headKey === 'price' ? (
-                      data[headKey].toLocaleString('ko-KR')
-                    ) : headKey === 'etc' && isDelete && onSubmit ? (
-                      <EtcBox>
-                        <ETC onClick={moveToDetailsPage(data.id)}>
-                          <BiDetail className='icon' /> 상세보기
-                        </ETC>
-                        <ETC onClick={() => (window.confirm('삭제하시겠습니까?') ? onSubmit(data.id)() : () => console.log('취소했씁니다'))}>
-                          <FaTrashRestoreAlt className='icon' /> 삭제하기
-                        </ETC>
-                      </EtcBox>
-                    ) : (
-                      data[headKey]
-                    )}
-                  </Td>
-                );
-              })}
-            </Tr>
-          );
-        })}
+        {itemsData.length > 1 ? (
+          itemsData.map((data, index) => {
+            return (
+              <Tr key={index}>
+                {headerKey.map(headKey => {
+                  return (
+                    <Td key={headKey + index}>
+                      {headKey === 'productName' && data.Images ? (
+                        <ImageBox>
+                          <CImage src={`${backUrl}/${data.Images[0].src}`} alt={headKey} width={100} height={100} />
+                          {data[headKey]}
+                        </ImageBox>
+                      ) : headKey === 'price' ? (
+                        data[headKey].toLocaleString('ko-KR')
+                      ) : headKey === 'etc' && isDelete && onSubmit ? (
+                        <EtcBox>
+                          <ETC onClick={moveToDetailsPage(data.id)}>
+                            <BiDetail className='icon' /> 상세보기
+                          </ETC>
+                          <ETC onClick={() => (window.confirm('삭제하시겠습니까?') ? onSubmit(data.id)() : () => console.log('취소했씁니다'))}>
+                            <FaTrashRestoreAlt className='icon' /> 삭제하기
+                          </ETC>
+                        </EtcBox>
+                      ) : (
+                        headKey !== 'etc' && data[headKey]
+                      )}
+                    </Td>
+                  );
+                })}
+              </Tr>
+            );
+          })
+        ) : (
+          <Empty />
+        )}
       </tbody>
     </Table>
   );

--- a/components/recycle/ProcessingDataCard.tsx
+++ b/components/recycle/ProcessingDataCard.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 const ProcessingDataCard = ({ Icon, DataTitle, LastData = 0, CurrentData = 0, Categori }: Props) => {
-  let percent = ((CurrentData - LastData) / LastData) * 100;
+  let percent = Math.floor(((CurrentData - LastData) / LastData) * 100);
 
   return (
     <CardBox>

--- a/components/recycle/ProcessingDataCard.tsx
+++ b/components/recycle/ProcessingDataCard.tsx
@@ -10,12 +10,12 @@ import { media } from '../../styles/media';
 type Props = {
   Icon: React.ReactElement;
   DataTitle: string;
-  LastData: number;
-  CurrentData: number;
+  LastData?: number;
+  CurrentData?: number;
   Categori?: string;
 };
 
-const ProcessingDataCard = ({ Icon, DataTitle, LastData, CurrentData, Categori }: Props) => {
+const ProcessingDataCard = ({ Icon, DataTitle, LastData = 0, CurrentData = 0, Categori }: Props) => {
   let percent = ((CurrentData - LastData) / LastData) * 100;
 
   return (

--- a/components/store/ATable.tsx
+++ b/components/store/ATable.tsx
@@ -3,7 +3,7 @@ import Router from 'next/router';
 import React, { useCallback } from 'react';
 import styled, { css } from 'styled-components';
 import { Empty } from 'antd';
-import { StoreHeaderType, StoreItemsType, ItemsArray } from '../store/TableData';
+import { StoreHeaderType, StoreItemsType, ItemsArray } from './TableData';
 
 import { backUrl } from '../../config/config';
 

--- a/components/store/TableData.ts
+++ b/components/store/TableData.ts
@@ -81,3 +81,32 @@ export const TestItems = [
     etc: 1,
   },
 ];
+
+export interface ImagesPros {
+  id: number;
+  ClothId: number;
+  src: string;
+}
+
+export interface ItemsArray {
+  Images: ImagesPros[];
+  UserId: number;
+  categori: string;
+  color: string;
+  createdAt: string;
+  description: string;
+  id: number;
+  price: number;
+  productName: string;
+  purchaseDay: string;
+  updatedAt: string;
+}
+
+export interface UserItemsData {
+  categori: string;
+  categoriNum: number;
+  idArray: number[];
+  items: ItemsArray[];
+  price: number;
+  total: number;
+}

--- a/pages/closet/store.tsx
+++ b/pages/closet/store.tsx
@@ -1,10 +1,18 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import Link from 'next/link';
 import Router from 'next/router';
 import { useDispatch } from 'react-redux';
 import * as t from '../../reducers/type';
+
+import axios from 'axios';
+import { END } from 'redux-saga';
+
+import { GetServerSidePropsContext } from 'next';
+import type { SagaStore } from '../../store/configureStore';
+
+import wrapper from '../../store/configureStore';
 
 import { Breadcrumb } from 'antd';
 
@@ -19,9 +27,49 @@ import ATable from '../../components/recycle/ATable';
 
 import { media } from '../../styles/media';
 import { StoreHeader, TestItems } from '../../components/store/TableData';
+import { useSelector } from 'react-redux';
+import { rootReducerType } from '../../reducers/types';
 
 const store = () => {
   const dispatch = useDispatch();
+  const { me } = useSelector((state: rootReducerType) => state.user);
+  const { userItems, indexArray } = useSelector((state: rootReducerType) => state.post);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (me) {
+      dispatch({
+        type: t.LOAD_ITEMS_REQUEST,
+        data: { id: me.id },
+      });
+    }
+  }, []);
+
+  let currentDate = new Date().getFullYear() + '-' + new Date().getMonth().toString().padStart(2, '0');
+  let modifiedItems = [];
+  let lastCategori = 0;
+  let lastData = 0;
+  let lastTotalPrice = 0;
+
+  if (userItems) {
+    for (let cloth of userItems?.items) {
+      modifiedItems.push({ ...cloth, purchaseDay: cloth.purchaseDay.substring(0, 7) });
+      if (cloth.purchaseDay.substring(0, 7) !== currentDate) {
+        lastData += 1;
+        lastTotalPrice += cloth.price;
+      }
+      if (cloth.purchaseDay.substring(0, 7) !== currentDate && cloth.categori === userItems.categori) {
+        lastCategori += 1;
+      }
+    }
+  }
+
+  console.log('indexArray', indexArray);
+
   const moveToAddPage = useCallback(() => {
     Router.push('/closet/add');
   }, []);
@@ -35,6 +83,10 @@ const store = () => {
     },
     []
   );
+
+  if (!hydrated) {
+    return null;
+  }
 
   return (
     <PageLayout>
@@ -60,9 +112,9 @@ const store = () => {
           </dl>
         </TitleSection>
         <CardSection>
-          <ProcessingDataCard Icon={<AiOutlineDatabase className='icon' />} DataTitle='Total Clothes' LastData={40} CurrentData={50} />
-          <ProcessingDataCard Icon={<GiPayMoney className='icon' />} DataTitle='Total Consumption' LastData={1200000} CurrentData={1800000} />
-          <ProcessingDataCard Icon={<CgRowFirst className='icon' />} DataTitle='Most Unit' LastData={12} CurrentData={15} Categori='Outer' />
+          <ProcessingDataCard Icon={<AiOutlineDatabase className='icon' />} DataTitle='Total Clothes' LastData={lastData} CurrentData={userItems?.total} />
+          <ProcessingDataCard Icon={<GiPayMoney className='icon' />} DataTitle='Total Consumption' LastData={lastTotalPrice} CurrentData={userItems?.price} />
+          <ProcessingDataCard Icon={<CgRowFirst className='icon' />} DataTitle='Most Unit' LastData={lastCategori} CurrentData={userItems?.categoriNum} Categori='Outer' />
         </CardSection>
         <AddSection>
           <DictionaryBox>
@@ -75,13 +127,31 @@ const store = () => {
           </AddButton>
         </AddSection>
         <section>
-          <ATable headData={StoreHeader} itemsData={TestItems} isDelete={true} onSubmit={deleteItemAtTable} />
+          <ATable headData={StoreHeader} itemsData={modifiedItems} isDelete={true} onSubmit={deleteItemAtTable} />
         </section>
         store
       </PageMainLayout>
     </PageLayout>
   );
 };
+
+export const getServerSideProps = wrapper.getServerSideProps(store => async (context: GetServerSidePropsContext) => {
+  const cookie = context.req ? context.req.headers.cookie : '';
+  axios.defaults.headers.Cookie = '';
+  if (context.req && cookie) {
+    axios.defaults.headers.Cookie = cookie;
+  }
+  store.dispatch({
+    // store에서 dispatch 하는 api
+    type: t.LOAD_TO_MY_INFO_REQUEST,
+  });
+
+  store.dispatch(END);
+  await (store as SagaStore).sagaTask?.toPromise();
+  return {
+    props: {},
+  };
+});
 
 export default store;
 

--- a/pages/closet/store.tsx
+++ b/pages/closet/store.tsx
@@ -14,7 +14,7 @@ import type { SagaStore } from '../../store/configureStore';
 
 import wrapper from '../../store/configureStore';
 
-import { Breadcrumb } from 'antd';
+import { Breadcrumb, Pagination, PaginationProps } from 'antd';
 
 import { AiOutlineDatabase, AiOutlinePlus } from 'react-icons/ai';
 import { GiPayMoney } from 'react-icons/gi';
@@ -23,7 +23,7 @@ import { CgRowFirst } from 'react-icons/cg';
 import PageLayout from '../../components/recycle/PageLayout';
 import PageMainLayout from '../../components/recycle/main/PageMainLayout';
 import ProcessingDataCard from '../../components/recycle/ProcessingDataCard';
-import ATable from '../../components/recycle/ATable';
+import ATable from '../../components/store/ATable';
 
 import { media } from '../../styles/media';
 import { StoreHeader, TestItems } from '../../components/store/TableData';
@@ -35,6 +35,7 @@ const store = () => {
   const { me } = useSelector((state: rootReducerType) => state.user);
   const { userItems, indexArray } = useSelector((state: rootReducerType) => state.post);
   const [hydrated, setHydrated] = useState(false);
+  const [current, setCurrent] = useState(1);
 
   useEffect(() => {
     setHydrated(true);
@@ -69,6 +70,11 @@ const store = () => {
   }
 
   console.log('indexArray', indexArray);
+  console.log('current', current);
+
+  const pageChange: PaginationProps['onChange'] = page => {
+    setCurrent(page);
+  };
 
   const moveToAddPage = useCallback(() => {
     Router.push('/closet/add');
@@ -126,9 +132,12 @@ const store = () => {
             <div>ADD PRODUCT</div>
           </AddButton>
         </AddSection>
-        <section>
+        <ItemsStoreSection>
           <ATable headData={StoreHeader} itemsData={modifiedItems} isDelete={true} onSubmit={deleteItemAtTable} />
-        </section>
+          <div>
+            <Pagination current={current} onChange={pageChange} total={userItems?.total} defaultPageSize={9} />
+          </div>
+        </ItemsStoreSection>
         store
       </PageMainLayout>
     </PageLayout>
@@ -275,5 +284,20 @@ const AddButton = styled.div`
       display: block;
       font-size: clamp(12px, 1.8vw, 14px);
     }
+  }
+`;
+
+const ItemsStoreSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: auto;
+  gap: 10px;
+
+  > div {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    width: 100%;
   }
 `;

--- a/reducers/post.tsx
+++ b/reducers/post.tsx
@@ -9,6 +9,9 @@ export const initialState: PostInitialState = {
   loadItemLoding: false,
   loadItemDone: false,
   loadItemError: false,
+  loadItemsLoding: false,
+  loadItemsDone: false,
+  loadItemsError: false,
   uploadItemsLoding: false,
   uploadItemsDone: false,
   uploadItemsError: false,
@@ -22,6 +25,8 @@ export const initialState: PostInitialState = {
   user: null,
   imagePath: [],
   singleItem: null,
+  indexArray: [],
+  userItems: null,
 };
 
 export default (state = initialState, action: AnyAction) => {
@@ -90,6 +95,26 @@ export default (state = initialState, action: AnyAction) => {
         break;
       }
       case t.LOAD_ITEM_FAILURE: {
+        draft.loadItemLoding = false;
+        draft.loadItemDone = false;
+        draft.loadItemError = action.error;
+        break;
+      }
+      case t.LOAD_ITEMS_REQUEST: {
+        draft.loadItemsLoding = true;
+        draft.loadItemsDone = false;
+        draft.loadItemsError = false;
+        break;
+      }
+      case t.LOAD_ITEMS_SUCCESS: {
+        draft.loadItemsLoding = false;
+        draft.loadItemsDone = true;
+        draft.loadItemsError = false;
+        draft.indexArray = action.data.idArray;
+        draft.userItems = action.data;
+        break;
+      }
+      case t.LOAD_ITEMS_FAILURE: {
         draft.loadItemLoding = false;
         draft.loadItemDone = false;
         draft.loadItemError = action.error;

--- a/reducers/type.tsx
+++ b/reducers/type.tsx
@@ -42,6 +42,10 @@ export const LOAD_ITEM_REQUEST = 'LOAD_ITEM_REQUEST' as const;
 export const LOAD_ITEM_SUCCESS = 'LOAD_ITEM_SUCCESS' as const;
 export const LOAD_ITEM_FAILURE = 'LOAD_ITEM_FAILURE' as const;
 
+export const LOAD_ITEMS_REQUEST = 'LOAD_ITEMS_REQUEST' as const;
+export const LOAD_ITEMS_SUCCESS = 'LOAD_ITEMS_SUCCESS' as const;
+export const LOAD_ITEMS_FAILURE = 'LOAD_ITEMS_FAILURE' as const;
+
 export const PATCH_ITEM_REQUEST = 'PATCH_ITEM_REQUEST' as const;
 export const PATCH_ITEM_SUCCESS = 'PATCH_ITEM_SUCCESS' as const;
 export const PATCH_ITEM_FAILURE = 'PATCH_ITEM_FAILURE' as const;

--- a/reducers/types/post.ts
+++ b/reducers/types/post.ts
@@ -1,3 +1,5 @@
+import { UserItemsData } from '../../components/store/TableData';
+
 export interface VisionSearch {
   name: string;
   confidence: number;
@@ -83,6 +85,9 @@ export interface PostInitialState {
   loadItemLoding: boolean;
   loadItemDone: boolean;
   loadItemError: boolean;
+  loadItemsLoding: boolean;
+  loadItemsDone: boolean;
+  loadItemsError: boolean;
   uploadItemsLoding: boolean;
   uploadItemsDone: boolean;
   uploadItemsError: boolean;
@@ -96,4 +101,6 @@ export interface PostInitialState {
   user: User | null;
   imagePath: ImagePathObject[];
   singleItem: (User & SingleItem) | null;
+  indexArray: number[];
+  userItems: UserItemsData | null;
 }

--- a/reducers/types/user.ts
+++ b/reducers/types/user.ts
@@ -1,3 +1,14 @@
+export interface User {
+  id: number;
+  email: string;
+  nickname: string;
+  src: string;
+  snsId: string;
+  provider: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface UserInitialState {
   loadToMyInfoDone: boolean;
   loadToMyInfoError: string | null;
@@ -10,7 +21,7 @@ export interface UserInitialState {
   signInLoading: boolean;
   signInDone: boolean;
   signInError: string | null;
-  me: {} | null;
+  me: User | null;
 }
 
 export interface UserInfo {

--- a/sagas/post.tsx
+++ b/sagas/post.tsx
@@ -84,6 +84,32 @@ function* loadItem(action: AnyAction) {
   }
 }
 
+type LoadItems = {
+  id: number;
+};
+
+function loadItemsAPI(data: LoadItems) {
+  return axios.get(`/posts/clothes/${data.id}`);
+}
+
+function* loadItems(action: AnyAction) {
+  try {
+    console.log('saga items load');
+    console.log(action.data);
+    const result: AxiosResponse<Success> = yield call(loadItemsAPI, action.data);
+    yield put({
+      type: t.LOAD_ITEMS_SUCCESS,
+      data: result.data,
+    });
+  } catch (err: any) {
+    console.log(err);
+    yield put({
+      type: t.LOAD_ITEMS_FAILURE,
+      error: err.response.data,
+    });
+  }
+}
+
 type patchProps = {
   items: AddInitialValue;
   clothId: number;
@@ -147,6 +173,10 @@ function* watchItemLoad() {
   yield takeLatest(t.LOAD_ITEM_REQUEST, loadItem);
 }
 
+function* watchItemsLoad() {
+  yield takeLatest(t.LOAD_ITEMS_REQUEST, loadItems);
+}
+
 function* watchItemPatch() {
   yield takeLatest(t.PATCH_ITEM_REQUEST, patchItem);
 }
@@ -156,5 +186,5 @@ function* watchItemDelete() {
 }
 
 export default function* postSaga() {
-  yield all([fork(watchImageUpload), fork(watchItemsUpload), fork(watchItemLoad), fork(watchItemPatch), fork(watchItemDelete)]);
+  yield all([fork(watchImageUpload), fork(watchItemsUpload), fork(watchItemLoad), fork(watchItemPatch), fork(watchItemDelete), fork(watchItemsLoad)]);
 }


### PR DESCRIPTION
- store 페이지 렌더링 시 로그인한 유저 정보를 가져온다
- 이후 id 값을 action data 로 넘겨준 뒤, 서버에서 userId 에 해당하는 데이터 중 9개만 가져온다
- 이 외 store 에서 사용될 총 의류량, 총 금액, 주된 카테고리 에서 데이터를 가져온다. 
- 받아올 데이터들의 타입을 지정해준다음 table 컴포넌트의 props 를 수정하였음