### PR TITLE
Fixed: Change indexArray to consider category-based pagination

### DIFF
--- a/components/recycle/ItemCard.tsx
+++ b/components/recycle/ItemCard.tsx
@@ -25,7 +25,7 @@ const ItemCard = ({ src, id, onSubmit }: CardProps) => {
     <ThumbnailWrapper>
       <Thumbnail>
         <Centered>
-          <CImage src={`${backUrl}/${src}`} alt={src} width={600} height={600} />
+          <CImage src={`${backUrl}/${src}`} alt={src} width={600} height={600} priority={true} />
           <HoverTumnail>
             <IconBox>
               <BiDetail className='icon' onClick={moveToDetailsPage(id)} />

--- a/config/config.ts
+++ b/config/config.ts
@@ -3,3 +3,4 @@ import axios from 'axios';
 export const backUrl = 'http://localhost:3065';
 
 export const fetcher = (url: string) => axios.get(url, { withCredentials: true }).then(result => result.data);
+

--- a/reducers/post.tsx
+++ b/reducers/post.tsx
@@ -59,11 +59,11 @@ export default (state = initialState, action: AnyAction) => {
         if (draft.userItems) {
           if (action.data.clothData.purchaseDay === draft.userItems.standardDate) {
             draft.userItems.total -= 1;
-            draft.indexArray = draft.indexArray.filter(id => id !== Number(action.data.clothId));
+            draft.indexArray = draft.indexArray.filter(item => item.id !== Number(action.data.clothId));
             draft.userItems.price -= action.data.clothData.price;
             draft.userItems.categori[action.data.clothData.categori] && draft.userItems.categori[action.data.clothData.categori]--;
           } else {
-            draft.indexArray = draft.indexArray.filter(id => id !== Number(action.data.clothId));
+            draft.indexArray = draft.indexArray.filter(item => item.id !== Number(action.data.clothId));
             draft.userItems.total -= 1;
             draft.userItems.lastTotal -= 1;
             draft.userItems.price -= action.data.clothData.price;

--- a/reducers/types/post.ts
+++ b/reducers/types/post.ts
@@ -80,6 +80,11 @@ export interface SingleItem {
   Images: Image[] | null;
 }
 
+export interface IndexArray {
+  id: number;
+  categori: string;
+}
+
 export interface PostInitialState {
   showDrawer: boolean;
   loadItemLoding: boolean;
@@ -101,6 +106,6 @@ export interface PostInitialState {
   user: User | null;
   imagePath: ImagePathObject[];
   singleItem: (User & SingleItem) | null;
-  indexArray: number[];
+  indexArray: IndexArray[];
   userItems: UserItemsData | null;
 }

--- a/sagas/post.tsx
+++ b/sagas/post.tsx
@@ -84,19 +84,15 @@ function* loadItem(action: AnyAction) {
   }
 }
 
-type LoadItems = {
-  id: number;
-};
-
-function loadItemsAPI(data: LoadItems) {
-  return axios.get(`/posts/clothes/${data.id}`);
+function loadItemsAPI() {
+  return axios.get(`/posts/clothes/`);
 }
 
 function* loadItems(action: AnyAction) {
   try {
     console.log('saga items load');
     console.log(action.data);
-    const result: AxiosResponse<Success> = yield call(loadItemsAPI, action.data);
+    const result: AxiosResponse<Success> = yield call(loadItemsAPI);
     yield put({
       type: t.LOAD_ITEMS_SUCCESS,
       data: result.data,


### PR DESCRIPTION
- 기존 페이지네이션의 총 데이터갯수는 전체 카테고리들의 합이였음
- 이제 필터를 통해 카테고리별 데이터를 렌더하기 때문에, 이에 따른 페이지네이션 역시 카테고리별 페이지네이션이 필요하였음
- 기존 id 만 가져오던 indexArray 에 categori 까지 추가하여 전달받고, store 페이지에서 filter 를 통해 categori 별로 array 조절