### PR TITLE
Add: CardBoard Skeleton

### DIFF
--- a/components/store/ATable.tsx
+++ b/components/store/ATable.tsx
@@ -50,7 +50,7 @@ const ATable = ({ headData, itemsData = [], isDelete, onSubmit, isLoading }: Tab
                     <Td key={headKey + index}>
                       {headKey === 'productName' && data.Images.length > 0 ? (
                         <ImageBox>
-                          <CImage src={`${backUrl}/${data.Images[0].src}`} alt={headKey} width={100} height={100} />
+                          <CImage src={`${backUrl}/${data.Images[0].src}`} alt={headKey} width={100} height={100} priority={true} />
                           {data[headKey]}
                         </ImageBox>
                       ) : headKey === 'price' ? (

--- a/components/store/CardBoard.tsx
+++ b/components/store/CardBoard.tsx
@@ -8,18 +8,32 @@ import { ItemsArray } from './TableData';
 interface Props {
   itemData: ItemsArray[] | undefined;
   onSubmit?: (id: number) => () => void;
+  isLoading?: boolean;
 }
 
-const CardBoard = ({ itemData, onSubmit }: Props) => {
+const loadingArray = Array(9)
+  .fill(0)
+  .map((v, i) => i);
+
+const CardBoard = ({ itemData, onSubmit, isLoading }: Props) => {
   return (
     <CardSection>
-      {itemData?.map(item => {
-        return (
-          <CardBox key={item.id}>
-            <ItemCard src={item.Images[0].src} id={item.id} onSubmit={onSubmit} />
-          </CardBox>
-        );
-      })}
+      {!isLoading &&
+        itemData?.map(item => {
+          return (
+            <CardBox key={item.id}>
+              <ItemCard src={item.Images[0].src} id={item.id} onSubmit={onSubmit} />
+            </CardBox>
+          );
+        })}
+      {isLoading &&
+        loadingArray.map(item => {
+          return (
+            <LoadingBox key={item}>
+              <Loading />
+            </LoadingBox>
+          );
+        })}
     </CardSection>
   );
 };
@@ -40,4 +54,14 @@ const CardBox = styled.div`
   width: 30%;
   height: auto;
   margin-bottom: 5%;
+`;
+
+const LoadingBox = styled(CardBox)`
+  background-color: ${({ theme }) => theme.colors.mainGrey};
+`;
+
+const Loading = styled.div`
+  width: 200px;
+  height: 200px;
+  background-color: ${({ theme }) => theme.colors.mainGrey};
 `;

--- a/hooks/usePagination.ts
+++ b/hooks/usePagination.ts
@@ -14,11 +14,12 @@ export const usePagination = <T>(categoriName: string, windowWidth: string) => {
     return `${backUrl}/posts/clothes/store?lastId=${previousPageData.nextCursor}&categori=${categoriName}&deviceType=${windowWidth}`;
   };
 
-  const { data: items, error: postsError, size, setSize } = useSWRInfinite<SWRResult<T>, Error>(getKey, fetcher);
+  const { data: items, error: postsError, size, setSize, isLoading: isItmesLoading } = useSWRInfinite<SWRResult<T>, Error>(getKey, fetcher);
 
   const posts = items?.map(item => item.items);
   const paginationPosts = posts?.flat();
   const loadingMore = posts && typeof posts[size - 1] === 'undefined';
+  const isEmpty = posts?.[0]?.length === 0;
   const isReachedEnd = posts && posts[posts.length - 1]?.length < 9;
 
   return {
@@ -28,5 +29,6 @@ export const usePagination = <T>(categoriName: string, windowWidth: string) => {
     setSize,
     loadingMore,
     isReachedEnd,
+    isItmesLoading,
   };
 };

--- a/pages/closet/store.tsx
+++ b/pages/closet/store.tsx
@@ -86,8 +86,7 @@ const store = () => {
 
     const io = new IntersectionObserver((entries, observer) => {
       entries.forEach(entry => {
-        // if (entry.intersectionRatio <= 0) return;
-        // console.log('inner');
+        if (entry.intersectionRatio <= 0) return;
         if (entry.isIntersecting) {
           setSize(prev => prev + 1);
         }

--- a/pages/closet/store.tsx
+++ b/pages/closet/store.tsx
@@ -52,10 +52,10 @@ const store = () => {
   let lastId = pageIndex >= 0 ? itemsIdArray[pageIndex].id : 0;
 
   const { data, error, isLoading, mutate } = useSWR(`${backUrl}/posts/clothes/store?lastId=${lastId}&categori=${categoriName}&deviceType=${windowWidth}`, fetcher);
-  const { paginationPosts, loadingMore, size, setSize, isReachedEnd } = usePagination<ItemsArray>(categoriName, windowWidth);
-  console.log('isReachedEnd', isReachedEnd);
+  const { paginationPosts, loadingMore, size, setSize, isReachedEnd, isItmesLoading } = usePagination<ItemsArray>(categoriName, windowWidth);
 
   console.log(paginationPosts);
+  console.log(isReachedEnd);
 
   useEffect(() => {
     setHydrated(true);
@@ -86,7 +86,8 @@ const store = () => {
 
     const io = new IntersectionObserver((entries, observer) => {
       entries.forEach(entry => {
-        if (entry.intersectionRatio <= 0) return;
+        // if (entry.intersectionRatio <= 0) return;
+        // console.log('inner');
         if (entry.isIntersecting) {
           setSize(prev => prev + 1);
         }
@@ -97,7 +98,7 @@ const store = () => {
     return () => {
       io.disconnect();
     };
-  }, [isReachedEnd, categoriName]);
+  }, [isReachedEnd, categoriName, windowWidth]);
 
   let modifiedItems = [];
   let accumulationItems = [];
@@ -219,7 +220,8 @@ const store = () => {
         <ItemsStoreSection>
           {windowWidth === 'desktop' && segment === 'Table' ? <ATable headData={StoreHeader} itemsData={modifiedItems} isDelete={true} onSubmit={deleteItemAtTable} isLoading={isLoading} /> : null}
           {windowWidth === 'desktop' && segment === 'Kanban' ? <CardBoard itemData={modifiedItems} onSubmit={deleteItemAtTable} /> : null}
-          {windowWidth === 'phone' ? <CardBoard itemData={accumulationItems} onSubmit={deleteItemAtTable} /> : null}
+          {windowWidth === 'phone' && !isItmesLoading ? <CardBoard itemData={accumulationItems} onSubmit={deleteItemAtTable} isLoading={false} /> : null}
+          {windowWidth === 'phone' && isItmesLoading ? <CardBoard itemData={accumulationItems} onSubmit={deleteItemAtTable} isLoading={true} /> : null}
           {windowWidth === 'desktop' ? (
             <div>
               <Pagination current={current} onChange={pageChange} total={itemsIdArray?.length} defaultPageSize={9} />


### PR DESCRIPTION
- 무한스크롤을 구현하던 도중, 카테고리를 변경할때마다 로딩이 안되는 문제가 발생
- 이유를 알아보니 카테고리를 변경하는 과정에서 데이터가 리셋이 되는데, 그 중간 로딩부분에 화면에 렌더링하는것이 아무것도 없어서, intersection Observer 의 타겟이 바로 교차되어, entry.intersecting 이 발동되게 됨
- 이로 인해 setSize(prev => prev + 1) 이 작동되면서, 끝 페이지보다 한번 더 이동한 상태로 데이터 요청이 들어가기 때문에 빈 데이터를 가져오게 됨
- 해결 방법은 로딩 기간동안 9개의 블록만큼의 높이를 차지하는 skeleton 을 넣어주면 됨