### PR TITLE
Fixed: 모바일 환경에서 데이터 삭제시 mutate 문제 해결, 디바이스 별 width를 ssr 시점에서 결정

### DIFF
--- a/hooks/usePagination.ts
+++ b/hooks/usePagination.ts
@@ -14,7 +14,7 @@ export const usePagination = <T>(categoriName: string, windowWidth: string) => {
     return `${backUrl}/posts/clothes/store?lastId=${previousPageData.nextCursor}&categori=${categoriName}&deviceType=${windowWidth}`;
   };
 
-  const { data: items, error: postsError, size, setSize, isLoading: isItmesLoading } = useSWRInfinite<SWRResult<T>, Error>(getKey, fetcher);
+  const { data: items, error: postsError, size, setSize, isLoading: isItmesLoading, mutate: infinitiMutate } = useSWRInfinite<SWRResult<T>, Error>(getKey, fetcher);
 
   const posts = items?.map(item => item.items);
   const paginationPosts = posts?.flat();
@@ -23,6 +23,7 @@ export const usePagination = <T>(categoriName: string, windowWidth: string) => {
   const isReachedEnd = posts && posts[posts.length - 1]?.length < 9;
 
   return {
+    items,
     paginationPosts,
     postsError,
     size,
@@ -30,5 +31,6 @@ export const usePagination = <T>(categoriName: string, windowWidth: string) => {
     loadingMore,
     isReachedEnd,
     isItmesLoading,
+    infinitiMutate,
   };
 };

--- a/pages/closet/store.tsx
+++ b/pages/closet/store.tsx
@@ -36,7 +36,11 @@ import { useSelector } from 'react-redux';
 import { rootReducerType } from '../../reducers/types';
 import { usePagination, SWRResult } from '../../hooks/usePagination';
 
-const store = () => {
+interface Props {
+  device: 'phone' | 'desktop';
+}
+
+const store = ({ device }: Props) => {
   const dispatch = useDispatch();
   const observerTargetElement = useRef<HTMLDivElement>(null);
   const { userItems, indexArray, deleteItemDone } = useSelector((state: rootReducerType) => state.post);
@@ -44,7 +48,7 @@ const store = () => {
   const [current, setCurrent] = useState(1);
   const [segment, setSegment] = useState<string | number>('Table');
   const [categoriName, setCategoriName] = useState('');
-  const [windowWidth, setWindowWidth] = useState('desktop');
+  const [windowWidth, setWindowWidth] = useState(device);
 
   let itemsIdArray = indexArray;
   if (categoriName) itemsIdArray = indexArray.filter(item => item.categori === categoriName);
@@ -54,7 +58,8 @@ const store = () => {
   const { data, error, isLoading, mutate } = useSWR(`${backUrl}/posts/clothes/store?lastId=${lastId}&categori=${categoriName}&deviceType=${windowWidth}`, fetcher);
   const { items, paginationPosts, loadingMore, size, setSize, isReachedEnd, isItmesLoading, infinitiMutate } = usePagination<ItemsArray>(categoriName, windowWidth);
 
-  console.log('items', items);
+  console.log('device', windowWidth);
+  console.log('data', data);
 
   useEffect(() => {
     setHydrated(true);
@@ -249,6 +254,11 @@ export const getServerSideProps = wrapper.getServerSideProps(store => async (con
   if (context.req && cookie) {
     axios.defaults.headers.Cookie = cookie;
   }
+  const userAgent = context.req ? context.req.headers['user-agent'] : navigator.userAgent;
+  let isMobile = false;
+  if (userAgent) {
+    isMobile = Boolean(userAgent.match(/Android|BlackBerry|iPhone|iPod|Opera Mini|IEMobile|WPDesktop/i));
+  }
   store.dispatch({
     // store에서 dispatch 하는 api
     type: t.LOAD_TO_MY_INFO_REQUEST,
@@ -261,7 +271,9 @@ export const getServerSideProps = wrapper.getServerSideProps(store => async (con
   store.dispatch(END);
   await (store as SagaStore).sagaTask?.toPromise();
   return {
-    props: {},
+    props: {
+      device: isMobile ? 'phone' : 'desktop',
+    },
   };
 });
 


### PR DESCRIPTION
- 모바일 환경에서의 의류 데이터는 useSWRInfinite 를 통해 가져온 데이터를 plat 하여 하나의 배열로 전환 한 뒤 렌더링을 시도하게 된다
- 기존과 같은 방식으로 mutate 를 시도하던 도중 문제가 발생했는데, 기존처럼 새로운 배열을 생성하여 삭제된 아이템의 id 를 filter 한 뒤 나머지 아이템들이 들어있는 배열을 mutate 해주게 되면, item과 nextcursor 를 하나의 객체로 담아서 전달해주는 기존의 useSWRInfinite의 data 구조와 일치하지 않아 mutate 를 적용하는 것이 불가능했다.
- 따라서 binding mutate 를 적용하기 위해서는 서버에서 전달받아 저장된 data 의 데이터 구조와 일치 시켜야 한다. 
- usePagination 에서 data 를 건내주고, 이후 삭제 함수에서 조건적으로 paginationData 가 존재할 경우 삭제된 아이템만 삭제하여 mutate 를 해주는 로직을 설정하였다.

```ts
      if (paginationPosts && items) {
        let newPostitems = [];
        for (let set of items) {
          let newItems = { ...set };
          let newPostData = set.items.filter(item => item.id !== id);
          newItems = { ...newItems, items: newPostData };
          newPostitems.push(newItems);
        }
        infinitiMutate([...newPostitems], false);
      }

```

- 이를 통해 binding mutate 를 적용할 수 있었다. 
- 다음에는 innerWidth 에 따라 테이블형을 삭제하게 되는데(모바일에서는 삭제), 처음 렌더링 시 초기 상태값이 desktop 으로 되어있어서 모바일 환경에서도 처음에는 테이블 데이터가 랜더링되는 문제 발생
- next.js 의 서버는 node.js 환경이기에 브라우저 환경에서 사용 가능한 window 객체를 사용할 수 없다. 사용하려면 DOM 트리가 렌더 완료 된 후 useEffect 를 통해 설정해주는 방법이 있다. 
- 하지만 왠만하면 useEffect 를 사용하기 싫어서, getServersideRender 를 사용하는 김에 header.user-agent 를 활용하여 현 디바이스의 정보를 받아 이에 따른 조건부 상태값 설정을 props 로 전달해줌으로서 초기 디바이스에 따른 상태값 설정을 결정할 수 있었다.